### PR TITLE
Fix package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "watch": "ng build --watch --configuration development",
+    "build:prod": "ng build --configuration=production",
+    "build:staging": "ng build --configuration=development",
+    "watch": "ng build --watch --configuration=development",
     "test": "ng test"
   },
   "dependencies": {


### PR DESCRIPTION
Pipeline was failing because the scripts in the package.json file were incorrect. This includes again the `build:prod` and `build:staging` scripts.

**Note:** Building the app in production will fail because of the filesize budget on the angular.json file. We may have to tweak them in order to properly build the app.

Can you ptal @nkoenig ? 