### PR TITLE
Correct output path in pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm install
 
@@ -57,7 +57,7 @@ jobs:
           aws-region: "us-east-1"
 
       - name: Upload package to S3 bucket
-        run: aws s3 sync dist/app s3://${{ secrets.S3_BUCKET }}
+        run: aws s3 sync dist s3://${{ secrets.S3_BUCKET }}
 
       - name: Invalidate Cloudfront
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
@@ -92,7 +92,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm install
 
@@ -107,7 +107,7 @@ jobs:
           aws-region: "us-east-1"
 
       - name: Upload package to S3 bucket
-        run: aws s3 sync dist/app s3://${{ secrets.S3_BUCKET }}
+        run: aws s3 sync dist s3://${{ secrets.S3_BUCKET }}
 
       - name: Invalidate Cloudfront
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'


### PR DESCRIPTION
While upgrading to Angular 14, we no longer use `dist/app` as our output path, we only use `dist`. This change fixes the pipelines, making it copy the right files into S3.

FYI @nkoenig . I'll proceed to merge this into `staging` to see if there are other issues with the pipeline. If everything goes well, the site will be up in Staging.