### PR TITLE
Allow uploading glb / gltf models

### DIFF
--- a/src/app/model/model.ts
+++ b/src/app/model/model.ts
@@ -11,11 +11,14 @@ export class Model extends FuelResource {
    * The extensions allowed by Model files.
    */
   public static allowedExtensions: string[] = [
+    'bin',
     'bvh',
     'config',
     'dae',
     'dds',
+    'glb',
     'glsl',
+    'gltf',
     'jpg',
     'material',
     'metal',


### PR DESCRIPTION
As of gz-sim garden GLB assets are supported but their extensions have not been added to the list of allowed extensions in the web portal making it impossible for users to upload models that contain these files.

This PR addresses the issue by adding:
* `glb` for the binary all in one file format
* `gltf` and `bin` for the separate file format, where the `gltf` contains a human readable json and the matching `.bin` contains all the binary buffers, such as vertices, UV coordinates, etc.