### PR TITLE
Download zip files from S3

### DIFF
--- a/src/app/fuel-resource/fuel-resource.service.ts
+++ b/src/app/fuel-resource/fuel-resource.service.ts
@@ -297,6 +297,14 @@ export abstract class FuelResourceService {
             return from(response.body.text()).pipe(
               mergeMap(url => this.http.get(url, { responseType: 'blob' })),
             );
+          default:
+            let msg = 'Error getting the zip file: Invalid Content-Type';
+            if (contentType) {
+              msg += ` (${contentType})`;
+            }
+            return throwError({
+              statusText: msg,
+            });
         }
       }),
       catchError(this.handleError)

--- a/src/app/ui-error/ui-error.ts
+++ b/src/app/ui-error/ui-error.ts
@@ -24,7 +24,7 @@ export class UiError {
    */
   constructor(httpResponse: HttpErrorResponse) {
     // Check if the error comes from the Gazebo server.
-    if (httpResponse.error.errcode) {
+    if (httpResponse.error?.errcode) {
       this.code = httpResponse.error.errcode;
       this.message = `Error #${httpResponse.error.errcode}: ${httpResponse.error.msg}`;
     } else {


### PR DESCRIPTION
This PR introduces a change required to access signed links from S3.

Fuel Server now works with redirects to S3, but we need some extra steps in the browser to access them. We need to request the S3 link directly and then manually do a GET request to it, instead of a redirect.

Can you ptal @nkoenig ?