### PR TITLE
Make like button refresh models and worlds

### DIFF
--- a/src/app/model/model.component.ts
+++ b/src/app/model/model.component.ts
@@ -331,9 +331,14 @@ export class ModelComponent implements OnInit, OnDestroy {
 
     request.subscribe(
       (response) => {
-        this.model.isLiked = !this.model.isLiked;
-        this.model.likes += 1 * (this.model.isLiked ? 1 : -1);
         this.disableLike = false;
+
+        // Refresh the Model.
+        this.modelService.get(this.model.owner, this.model.name).subscribe(
+          (model) => {
+            this.model = model;
+            this.getFiles();
+          });
       },
       (error) => {
         this.snackBar.open(error.message, 'Got it');

--- a/src/app/model/model.component.ts
+++ b/src/app/model/model.component.ts
@@ -331,8 +331,8 @@ export class ModelComponent implements OnInit, OnDestroy {
 
     request.subscribe(
       (response) => {
-        this.model.likes = response;
         this.model.isLiked = !this.model.isLiked;
+        this.model.likes += 1 * (this.model.isLiked ? 1 : -1);
         this.disableLike = false;
       },
       (error) => {

--- a/src/app/world/world.component.ts
+++ b/src/app/world/world.component.ts
@@ -309,9 +309,14 @@ export class WorldComponent implements OnInit, OnDestroy {
 
     request.subscribe(
       (response) => {
-        this.world.isLiked = !this.world.isLiked;
-        this.world.likes += 1 * (this.world.isLiked ? 1 : -1);
         this.disableLike = false;
+
+        // Refresh the World.
+        this.worldService.get(this.world.owner, this.world.name).subscribe(
+            (world) => {
+              this.world = world;
+              this.getFiles();
+            });
       },
       (error) => {
         this.snackBar.open(error.message, 'Got it');

--- a/src/app/world/world.component.ts
+++ b/src/app/world/world.component.ts
@@ -309,8 +309,8 @@ export class WorldComponent implements OnInit, OnDestroy {
 
     request.subscribe(
       (response) => {
-        this.world.likes = response;
         this.world.isLiked = !this.world.isLiked;
+        this.world.likes += 1 * (this.world.isLiked ? 1 : -1);
         this.disableLike = false;
       },
       (error) => {


### PR DESCRIPTION
https://github.com/gazebo-web/fuel-server/pull/16 changes the way likes and downloads are computed. Due to the changes, the endpoints no longer return the total number of likes/downloads as they previously did.

This PR updates the `likeClick` handlers for both models and worlds so that they are requested from the backend to report the correct value.