### PR TITLE
Disable thumbnail generator because the THREE dependency is broken wi…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -126,7 +126,9 @@ import { SimulationService } from './cloudsim';
 
 import { TagsComponent } from './tags';
 import { TextInputDialogComponent } from './text-input-dialog/text-input-dialog.component';
-import { ThumbnailGeneratorComponent } from './model/edit/thumbnail-generator/thumbnail-generator.component';
+
+// nkoenig: Disabling until we fix the THREE dependency
+// import { ThumbnailGeneratorComponent } from './model/edit/thumbnail-generator/thumbnail-generator.component';
 import { UserComponent } from './user/user.component';
 import { UserModelsResolver } from './model/list/user-models.resolver';
 import { UserService } from './user/user.service';
@@ -199,7 +201,10 @@ import { WorldService } from './world/world.service';
     SimulationRulesComponent,
     TagsComponent,
     TextInputDialogComponent,
-    ThumbnailGeneratorComponent,
+
+    // nkoenig: Disabling until we fix the THREE dependency
+    // ThumbnailGeneratorComponent,
+ 
     UserComponent,
     VisualizationComponent,
     WorldComponent,

--- a/src/app/model/edit/edit-model.component.html
+++ b/src/app/model/edit/edit-model.component.html
@@ -51,9 +51,11 @@
                 fxFill>
       </gz-metadata>
 
+      <!-- nkoenig: Disabling until we fix the THREE dependency
       <h2>Thumbnails</h2>
 
       <gz-thumbnail-generator [resource]="model"></gz-thumbnail-generator>
+      -->
 
       <h2>Replace files</h2>
 

--- a/src/app/world/edit/edit-world.component.html
+++ b/src/app/world/edit/edit-world.component.html
@@ -45,9 +45,11 @@
                     fxFill>
       </gz-metadata>
 
+      <!-- nkoenig: Disabling until we fix THREE dependency
       <h2>Thumbnails</h2>
 
       <gz-thumbnail-generator [resource]="world"></gz-thumbnail-generator>
+      -->
 
       <h2>Replace files</h2>
 


### PR DESCRIPTION
Disable thumbnail generator because the THREE dependency is broken with the move to gzweb2