### PR TITLE
Testing thumbnail generator disablement. (#31)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -48,12 +48,12 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "4mb"
+                  "maximumError": "15mb"
                 },
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "100kb"
+                  "maximumError": "200kb"
                 }
               ],
               "fileReplacements": [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -126,7 +126,9 @@ import { SimulationService } from './cloudsim';
 
 import { TagsComponent } from './tags';
 import { TextInputDialogComponent } from './text-input-dialog/text-input-dialog.component';
-import { ThumbnailGeneratorComponent } from './model/edit/thumbnail-generator/thumbnail-generator.component';
+
+// nkoenig: Disabling until we fix the THREE dependency
+// import { ThumbnailGeneratorComponent } from './model/edit/thumbnail-generator/thumbnail-generator.component';
 import { UserComponent } from './user/user.component';
 import { UserModelsResolver } from './model/list/user-models.resolver';
 import { UserService } from './user/user.service';
@@ -199,7 +201,10 @@ import { WorldService } from './world/world.service';
     SimulationRulesComponent,
     TagsComponent,
     TextInputDialogComponent,
-    ThumbnailGeneratorComponent,
+
+    // nkoenig: Disabling until we fix the THREE dependency
+    // ThumbnailGeneratorComponent,
+ 
     UserComponent,
     VisualizationComponent,
     WorldComponent,

--- a/src/app/model/edit/edit-model.component.html
+++ b/src/app/model/edit/edit-model.component.html
@@ -51,9 +51,11 @@
                 fxFill>
       </gz-metadata>
 
+      <!-- nkoenig: Disabling until we fix the THREE dependency
       <h2>Thumbnails</h2>
 
       <gz-thumbnail-generator [resource]="model"></gz-thumbnail-generator>
+      -->
 
       <h2>Replace files</h2>
 

--- a/src/app/world/edit/edit-world.component.html
+++ b/src/app/world/edit/edit-world.component.html
@@ -45,9 +45,11 @@
                     fxFill>
       </gz-metadata>
 
+      <!-- nkoenig: Disabling until we fix THREE dependency
       <h2>Thumbnails</h2>
 
       <gz-thumbnail-generator [resource]="world"></gz-thumbnail-generator>
+      -->
 
       <h2>Replace files</h2>
 


### PR DESCRIPTION
* Prod to main (#29)

* Gzweb2 → Main (#26) (#27)

* angular 10 to 11



* package updates



* ngx-markdown 14



* Migrated to angular14



* Ignore .angular directory



* Added swiper



* Fix font size



* cleanup



* Added missing files



* Removed font-awesome



* changes



* Alphabetize



* Restore icons

* Gallery Component

* Use Gallery Component in Models and Worlds

* Hide thumbnails if there's just one image

* nit: remove console log

* Remove swiper stylesheet from src

* Remove NgxGalleryModule from tests

* Remove Infinite Scroll from tests

* Remove Portal and Logfiles

* Remove Infinite Scroll Dependency

* Add pagination to GET List of Fuel Resources

* Use pagination in Fuel Resource List

* Paginator in the Fuel Resource List Component

* Pagination in Models and Worlds

* Scroll on Navigation - Upgrade

* Fix Collection Dialog

* Paginated collections on Service

* Use new collections Service params

* Update Collection Services and implementations

* Pagination parameters in FuelResource List

* Service fixes

* Pagination in collections

* Collection pagination inside Models and Worlds

* Pagination in Organizations

* Update to gzweb2 (#16)

* Use gzweb2 from npm



* fix button



* Added script to update fuel model uri



* Fix deployment



* Update package.json



* Upgrade to angular 14 (#8)

* angular 10 to 11



* package updates



* ngx-markdown 14



* Migrated to angular14



* Ignore .angular directory



* Added swiper



* Fix font size



* cleanup



* Added missing files



* Removed font-awesome



* changes



* Alphabetize



* Restore icons

* Gallery Component

* Use Gallery Component in Models and Worlds

* Hide thumbnails if there's just one image

* nit: remove console log

* Remove swiper stylesheet from src

* Remove NgxGalleryModule from tests

* Remove Infinite Scroll from tests

* Remove Portal and Logfiles

* Remove Infinite Scroll Dependency

* Add pagination to GET List of Fuel Resources

* Use pagination in Fuel Resource List

* Paginator in the Fuel Resource List Component

* Pagination in Models and Worlds

* Scroll on Navigation - Upgrade

* Fix Collection Dialog

* Paginated collections on Service

* Use new collections Service params

* Update Collection Services and implementations

* Pagination parameters in FuelResource List

* Service fixes

* Pagination in collections

* Collection pagination inside Models and Worlds

* Pagination in Organizations

---------







* remove console log



* Fix package.json scripts

* Correct output path in pipelines

* Fix Connection status and controls

---------








* Use gzweb2 to render Model and Worlds (#23)

* Don't use the old Gz3D Detector

* Update styles and template using AssetViewer

* Remove old spec file

* Asset Viewer in SDF Viewer Component

* Remove Detector from FileUploader as well

* Token for private assets

* Worlds - Special Lighting

* gzweb version update

---------







* Increase budgets



* Bump budgets



---------







* Disable thumbnail generator because the THREE dependency is broken with the move to gzweb2 (#30)



---------